### PR TITLE
v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ es5
 sandbox
 
 .env
+
+# Tizen Studio files
+.project

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mux-player-sdk-framework",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "author": "Mux, Inc.",
   "description": "Mux analytics plugin for Samsung Tizen AVPlay applications",
   "main": "dist/tizen-mux.js",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-promise": "^1.3.2",
     "eslint-plugin-standard": "^1.3.2",
     "global": "^4.3.0",
-    "mux-embed": "^2.8.0",
+    "mux-embed": "^3.1.0",
     "npm-run-all": "^2.2.0",
     "nsp": "^2.4.0",
     "path": "^0.12.7",

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const monitorTizenPlayer = function (player, options) {
 
   // AVPlay only allows for one listener to be set, so we need to
   // allow the customer to pass their own listener
-  const passthroughPlaybackCallback = assign({
+  const passthroughPlaybackListener = assign({
     onbufferingstart: function () { return; },
     onbufferingprogress: function (percent) { return; },
     onbufferingcomplete: function () { return; },
@@ -43,7 +43,7 @@ const monitorTizenPlayer = function (player, options) {
     onevent: function (eventType, eventData) { return; },
     onsubtitlechange: function (duration, text, type, attriCount, attributes) { return; },
     ondrmevent: function (drmEvent, drmData) { return; }
-  }, options.playbackCallback || {});
+  }, options.playbackListener || {});
 
   // Retrieve the ID and the player element
   const playerID = generateShortId();
@@ -130,13 +130,13 @@ const monitorTizenPlayer = function (player, options) {
         loadStarts = true;
       }
       setTimeout(() => {
-        passthroughPlaybackCallback.onbufferingstart();
+        passthroughPlaybackListener.onbufferingstart();
       }, 0);
     },
 
     onbufferingprogress: function (percent) {
       setTimeout(() => {
-        passthroughPlaybackCallback.onbufferingprogress(percent);
+        passthroughPlaybackListener.onbufferingprogress(percent);
       }, 0);
     },
 
@@ -147,21 +147,21 @@ const monitorTizenPlayer = function (player, options) {
         player.mux.emit('seeked');
       }
       setTimeout(() => {
-        player.playbackCallback.onbufferingcomplete();
+        player.playbackListener.onbufferingcomplete();
       }, 0);
     },
 
     oncurrentplaytime: function (currentTime) {
       player.mux.emit('timeupdate');
       setTimeout(() => {
-        player.playbackCallback.oncurrentplaytime(currentTime);
+        player.playbackListener.oncurrentplaytime(currentTime);
       }, 0);
     },
 
     onstreamcompleted: function () {
       player.mux.emit('ended');
       setTimeout(() => {
-        player.playbackCallback.onstreamcompleted();
+        player.playbackListener.onstreamcompleted();
       }, 0);
     },
 
@@ -177,7 +177,7 @@ const monitorTizenPlayer = function (player, options) {
         // Note: This event has the same problem as PLAYER_MSG_FRAGMENT_INFO.
       }
       setTimeout(() => {
-        player.playbackCallback.onevent(eventType, eventData);
+        player.playbackListener.onevent(eventType, eventData);
       }, 0);
     },
 
@@ -185,19 +185,19 @@ const monitorTizenPlayer = function (player, options) {
       if (!options.automaticErrorTracking) { return; }
       player.mux.emit('error', { player_error_code: -1, player_error_message: eventType });
       setTimeout(() => {
-        player.playbackCallback.onerror(eventType);
+        player.playbackListener.onerror(eventType);
       }, 0);
     },
 
     ondrmevent: function (drmEvent, drmData) {
       setTimeout(() => {
-        player.playbackCallback.ondrmevent(drmEvent, drmData);
+        player.playbackListener.ondrmevent(drmEvent, drmData);
       }, 0);
     },
 
     onsubtitlechange: function (duration, text, type, attriCount, attributes) {
       setTimeout(() => {
-        player.playbackCallback.onsubtitlechange(duration, text, type, attriCount, attributes);
+        player.playbackListener.onsubtitlechange(duration, text, type, attriCount, attributes);
       }, 0);
     }
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3168,10 +3168,10 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-mux-embed@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/mux-embed/-/mux-embed-2.8.0.tgz#16ed2019b79f4fa775c828c09dd1ab57a4d75d10"
-  integrity sha512-GMMFDLKc1Z0m4szsq2tPTDDZ4BpkxZQcjdl26OGMmF0nTcO9LlispbCyy57Sqnd2mevnycLYKfhyjy24OsEl5g==
+mux-embed@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mux-embed/-/mux-embed-3.1.0.tgz#7584cb4c1dcf519f7f30f1deaa9bad9322bfc11e"
+  integrity sha512-YJemZ9XQSYpskq1V09jXOTWLkLtdWTMHtSDvpjTELH00oXBguZkCJuIjl0yC7OpzecPcKDckUZNCVdBCD8Eh7Q==
 
 nan@^2.9.2:
   version "2.10.0"


### PR DESCRIPTION
Minor change to allow for clearly documenting. Previously, you had to put the other playbackListener on a random property of the player object, which didn't feel right. It was also not really documented, so this I think cleans it up a bit and lets us document it.

Also bumps mux-embed to 3.1.0, to use the new timestamps